### PR TITLE
Add destructive-foreground to css variables

### DIFF
--- a/packages/mist-kit/README.md
+++ b/packages/mist-kit/README.md
@@ -26,6 +26,7 @@ Copy and paste the following CSS variables into your project's global CSS (e.g.,
     --accent: var(--color-zinc-700);
     --accent-foreground: var(--color-white);
     --destructive: var(--color-red-600);
+    --destructive-foreground: var(--color-white);
     --border: var(--color-zinc-200);
     --input: var(--color-zinc-200);
     --ring: var(--color-indigo-500);


### PR DESCRIPTION
Adding `--destructive-foreground` to css variables

| before | after |
| ------ | ------ |
| <img width="173" alt="Screenshot 2025-05-14 at 09 51 31" src="https://github.com/user-attachments/assets/f45a46ad-4d79-4bd1-a52d-598f4e8c62ff" /> | <img width="173" alt="Screenshot 2025-05-14 at 09 51 09" src="https://github.com/user-attachments/assets/8959284f-c4c6-4821-b4a2-defd0192b4c3" /> |

